### PR TITLE
update field dateReceived to dateCreated, sentry api change

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -120,12 +120,12 @@ function handle_events(item, options){
     const { issues } = options;
     const { remove_fields } = options;
 
-    var { dateReceived } = item;
-    dateReceived = new Date(dateReceived);
+    var { dateCreated } = item;
+    dateCreated = new Date(dateCreated);
 
     var value = {value:{},finished:false, add:true }
 
-    if ((dateReceived >= period_from) && (dateReceived < period_to)){
+    if ((dateCreated >= period_from) && (dateCreated < period_to)){
 
         const { groupID } = item;
         if (issues.includes(groupID)){
@@ -141,11 +141,11 @@ function handle_events(item, options){
 
     }
 
-    if(dateReceived < period_from) {
+    if(dateCreated < period_from) {
         value.finished = true;
         value.add = false;
     }
-    if(dateReceived >= period_to) {
+    if(dateCreated >= period_to) {
         value.add = false;
     }
     return(value);


### PR DESCRIPTION
As of 26.08.2021, the response contains field dateCreated, according to https://docs.sentry.io/api/events/list-a-projects-events/ .